### PR TITLE
Adjust article image styling

### DIFF
--- a/themes/hexo-xnew/source/styles/basic.styl
+++ b/themes/hexo-xnew/source/styles/basic.styl
@@ -69,10 +69,15 @@ article.full
     border-radius 5px
     margin-left 0
   img
-    border-radius 3px
+    border-radius 8px
+    box-shadow 0 8px 24px rgba(0,0,0,.08)
+    display block
     height auto
-    margin-top 20px
-    max-width 70% 
+    margin 24px auto
+    max-width 100%
+  .image-small,
+  .post-image--small
+    max-width 70%
   code
     font-family "Fantasque Sans Mono"
   p code,


### PR DESCRIPTION
### Motivation
- Make article images render at their available width and appear visually centered within posts.
- Improve visual polish by increasing corner radius and adding a subtle shadow while preserving an option for smaller inline images.

### Description
- Updated `article.full img` in `themes/hexo-xnew/source/styles/basic.styl` to use `max-width: 100%`, `display: block`, and `margin: 24px auto` so images are centered and responsive.
- Increased `border-radius` to `8px` and added `box-shadow: 0 8px 24px rgba(0,0,0,.08)` for a light elevated effect, while keeping `height: auto`.
- Added helper classes `.image-small` and `.post-image--small` with `max-width: 70%` to preserve the previous small-image behavior when needed.

### Testing
- Ran `git diff --check`, which completed without issues.
- Attempted `npm ci`, which did not complete successfully in this environment (install stalled with warnings/timeouts).
- Ran `npm run build`, which failed because the local `hexo` binary was not available (`sh: 1: hexo: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54f739596c8321a3b61ddef723f8dc)