### PR TITLE
重构主题颜色变量

### DIFF
--- a/themes/hexo-xnew/source/styles/basic.styl
+++ b/themes/hexo-xnew/source/styles/basic.styl
@@ -18,7 +18,7 @@
 
 article.full
   a
-    color lighten($body-color, 50%)
+    color $link-color
     transition color ease .3s
     &:hover
       color $link-article-color

--- a/themes/hexo-xnew/source/styles/header.styl
+++ b/themes/hexo-xnew/source/styles/header.styl
@@ -55,14 +55,16 @@ header
         a
           color $header-li-color
         a:hover
+          color $title-color
           text-decoration underline
+          transition color .3s ease
     .xnews-icon
       margin-top 10px
       font-family xnews-icon
       font-size 1.5em
       a
         margin 4px
-        color #444
+        color $header-icon-color
         &:hover
           color $title-color
           transition color .3s ease

--- a/themes/hexo-xnew/source/styles/main.styl
+++ b/themes/hexo-xnew/source/styles/main.styl
@@ -21,7 +21,7 @@ main
       transition color .3s ease
       color $body-link-hover-color
   .post-meta
-    color #a4a4a4
+    color lighten($muted-color, 10%)
     display inline-block
     margin 0
     font-size 0.6em
@@ -79,7 +79,7 @@ main
     max-width 100%
     float right
     border-radius 15px
-    border 1px solid #d3d3d3
+    border 1px solid $border-color
     padding 2rem
     margin-left 20px
     display none
@@ -96,16 +96,16 @@ main
     text-align center
     position relative
     padding 4rem 0
-    border 1px solid #d3d3d3
+    border 1px solid $border-color
     font-size 1em
     line-height 2.1em
-    color #8a8a8a
-    background #ececec
+    color $muted-color
+    background $surface-color
     a
       color lighten($body-color, 20%)
       font-weight 700
     .copyright
-      color #737373
+      color darken($muted-color, 10%)
       font-weight 500
     .intro
       font-size 0.7em

--- a/themes/hexo-xnew/source/styles/variables.styl
+++ b/themes/hexo-xnew/source/styles/variables.styl
@@ -2,9 +2,14 @@ $body-color = #222222
 $header-line-color = #35101A
 $title-color = #CA314D
 $description-color = #FDF2E4
-$header-li-color = #CA314D
-$body-link-hover-color = #CA314D
-$link-article-color = #CA314D
+$link-color = #8F2437
+$muted-color = #8a8a8a
+$border-color = #d3d3d3
+$surface-color = #ececec
+$header-li-color = #A72A40
+$header-icon-color = #5F4248
+$body-link-hover-color = $title-color
+$link-article-color = $title-color
 
 $background-color = #f7f6f5
 


### PR DESCRIPTION
### Motivation
- 保留 `$title-color = #CA314D` 作为品牌主色，同时引入更深的正文链接色与柔和的辅助色以改善默认/悬停对比。 
- 将导航与图标的默认色调降低饱和度，避免页面默认全部使用高饱和红色，同时在悬停时保持更鲜明的品牌色。 
- 统一替换样式文件中散落的硬编码灰色，便于后续维护与主题配色调整。 

### Description
- 在 `themes/hexo-xnew/source/styles/variables.styl` 中新增变量：`$link-color`、`$muted-color`、`$border-color`、`$surface-color`、`$header-icon-color`，并将 `$body-link-hover-color` 保持为 `$title-color`。 
- 在 `themes/hexo-xnew/source/styles/header.styl` 中将导航链接默认色调整为 `$header-li-color`，图标默认色使用 `$header-icon-color`，并在 `a:hover` 中显式切换到 `$title-color` 并添加过渡。 
- 在 `themes/hexo-xnew/source/styles/main.styl` 中将原先硬编码的 `#a4a4a4`、`#d3d3d3`、`#ececec`、`#8a8a8a` 替换为 `lighten($muted-color, 10%)`、`$border-color`、`$surface-color`、`$muted-color`/`darken($muted-color, 10%)` 等变量表达。 
- 在 `themes/hexo-xnew/source/styles/basic.styl` 中将文章内链接默认色从 `lighten($body-color, 50%)` 替换为更深的 `$link-color`，悬停使用 `$link-article-color`。 

### Testing
- 已运行 `git diff --check`，结果通过且无样式冲突。 
- 运行 `npm run build` 时失败，原因是本地环境中未安装全局 `hexo` 可执行文件（`hexo: not found`）。 
- 尝试执行 `npm ci` 以安装依赖时出现大量 warning 并且安装过程在 CI 环境中长时间无输出后被终止，因此无法完成本地完整构建验证。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54f720e14883218519fd8d8eaeca80)