### PR TITLE
Adjust header typography responsiveness

### DIFF
--- a/themes/hexo-xnew/source/styles/header.styl
+++ b/themes/hexo-xnew/source/styles/header.styl
@@ -21,10 +21,10 @@ header
   h1
     font-family: '喜鹊招牌体', $cu-font-family;
     font-weight: normal;
-    font-size 3.5em
+    font-size 2.6em
     margin-top 20px
-    line-height 1em
-    letter-spacing -1px
+    line-height 1.12em
+    letter-spacing 0
     text-shadow 0 1px 6px hsla(0, 0, 0, .5)
     a
       color $title-color
@@ -32,9 +32,11 @@ header
     color $description-color
     font-family: '喜鹊万人造字体', $cu-font-family;
     letter-spacing 0
-    margin 0
+    margin 0 auto
+    max-width 22em
+    line-height 1.45em
     text-shadow 0 1px 3px hsla(0, 0, 0, .35)
-    font-size 2em
+    font-size 1.25em
   nav
     ul
       list-style none
@@ -85,6 +87,15 @@ header
       overflow hidden
       text-align right
       padding 40px
+      h1
+        font-size 3.5em
+        line-height 1.05em
+        letter-spacing -.5px
+      p
+        margin 0 0 0 auto
+        max-width 18em
+        line-height 1.4em
+        font-size 1.55em
     nav
       ul
         padding-top 24px


### PR DESCRIPTION
### Motivation
- Improve mobile readability by reducing header title and subtitle sizes and preventing subtitle overflow when text is long.
- Preserve the existing Chinese decorative fonts while reducing the negative `letter-spacing` that harms legibility on Chinese text.
- Restore stronger desktop visual weight for the title inside the `@media (min-width 720px)` breakpoint while keeping subtitle wrapping controlled.

### Description
- Updated `themes/hexo-xnew/source/styles/header.styl` to set mobile `header h1` `font-size` to `2.6em`, `line-height` to `1.12`, and `letter-spacing` to `0`.
- Adjusted mobile `header p` to `font-size` `1.25em`, `margin: 0 auto`, `max-width: 22em`, and `line-height: 1.45` to avoid compressed long subtitles.
- Added desktop rules inside `@media (min-width 720px)` to restore `h1` to `3.5em` with `line-height: 1.05` and `letter-spacing: -.5px`, and to constrain `p` with `max-width: 18em`, `font-size: 1.55em`, and `line-height: 1.4`.
- Changed only `themes/hexo-xnew/source/styles/header.styl` and committed the update.

### Testing
- Ran `git diff --check`, which passed without issues.
- Ran `npm run build`, which failed because the local `hexo` binary is not available in this environment.
- Ran `npm ci`, which produced `MaxListenersExceededWarning` warnings and did not enable a successful `hexo generate` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54f71299c48321aea3393f8f4c20ea)