### PR TITLE
将文章列表改为卡片样式并优化间距与排版

### DIFF
--- a/themes/hexo-xnew/source/styles/main.styl
+++ b/themes/hexo-xnew/source/styles/main.styl
@@ -21,10 +21,11 @@ main
       transition color .3s ease
       color $body-link-hover-color
   .post-meta
-    color #a4a4a4
+    color lighten($body-color, 38%)
     display inline-block
+    font-size .82rem
+    line-height 1.6
     margin 0
-    font-size 0.6em
   article.item, article.full
     p, li, blockquote
       font-family: '喜鹊聚珍体', $cu-font-family;
@@ -37,8 +38,16 @@ main
   article blockquote
     font-family: '喜鹊聚珍体', $cu-font-family;
   article.item
-    border-bottom 1px solid hsla(0, 0, 0, .15)
+    background rgba(255, 255, 255, .94)
+    border-radius 18px
+    box-shadow 0 12px 34px rgba(0, 0, 0, .08)
+    box-sizing border-box
     color $body-color
+    padding 24px
+    transition box-shadow .3s ease, transform .3s ease
+    &:hover
+      box-shadow 0 16px 42px rgba(0, 0, 0, .12)
+      transform translateY(-2px)
     h2
       break-word normal
       color $body-color
@@ -50,21 +59,18 @@ main
       line-height 1.2em
       text-indent -2px
     p.post-excerpt
-      font-size 1em
+      color lighten($body-color, 16%)
+      font-size 1rem
+      line-height 1.85
       margin 16px 0 0 0
     &:after
-      display block
+      display none
       content ''
-      width 7px
-      height 7px
-      border darken($background-color, 12%) 1px solid
-      position relative
-      top 5px
-      left 50%
-      margin-left -5px
-      background darken($background-color, 15%)
-      border-radius 100%
-      box-shadow $background-color 0 0 0 5px
+  article.item + article.item
+    margin-top 28px
+  a.article + a.article
+    article.item
+      margin-top 28px
   div.pagination
     margin-top 20px
     > *
@@ -118,7 +124,10 @@ main
       padding 40px
       article.item
         padding 40px
-        &:after
-          top 45px
+      article.item + article.item
+        margin-top 34px
+      a.article + a.article
+        article.item
+          margin-top 34px
       .article-toc
         display block


### PR DESCRIPTION
### Motivation
- 将线性分隔的文章列表改为更现代的卡片风格以提升可读性与视觉层次。
- 减少当前中心小圆点装饰与卡片样式的冲突，并在桌面/移动端都保持舒适的阅读节奏。

### Description
- 在 `themes/hexo-xnew/source/styles/main.styl` 中为 `article.item` 添加半透明白色背景、`border-radius: 18px`、柔和 `box-shadow`、`box-sizing` 与 `padding`，并加入悬停提升效果与平滑过渡。 
- 隐藏原有的 `article.item:after` 中央小圆点装饰，改用卡片间距分隔并为 `article.item + article.item` 及 `a.article + a.article article.item` 统一设置竖向间距。 
- 优化 `.post-meta` 的颜色、字号与行高，以及 `p.post-excerpt` 的颜色、字号与行高以强化信息层级。 
- 在 `@media (min-width 720px)` 下保留更大的卡片内边距并把卡片间距调整为更宽的值以适配桌面阅读。 

### Testing
- 运行 `git diff --check`，检查未报问题且样式变更通过静态差异检查。 
- 尝试运行 `npm ci` 以安装依赖，但在当前环境中安装过程出现长时间无响应并被中止（未成功）。
- 尝试运行 `npm run build`，在依赖未完成安装的情况下 `hexo` 二进制不可用导致构建失败。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54f6ee84008321b223bc3a7c781381)