### PR TITLE
Refactor cube page CSS, add variables, focus styles and warm theme

### DIFF
--- a/source/cube/assets/css/styles.css
+++ b/source/cube/assets/css/styles.css
@@ -1,6 +1,490 @@
 @font-face {
-    /* font-properties */
-    font-family: '喜鹊万人造字体';
-    src: url('https://dm.nbut.ac.cn/xcoder/%E5%96%9C%E9%B9%8A%E4%B8%87%E4%BA%BA%E9%80%A0%E5%AD%97%E4%BD%93.ttf');
+  font-family: '喜鹊万人造字体';
+  src: url('https://dm.nbut.ac.cn/xcoder/%E5%96%9C%E9%B9%8A%E4%B8%87%E4%BA%BA%E9%80%A0%E5%AD%97%E4%BD%93.ttf');
+}
+
+/* --------------------------------------------------------------------------
+   base
+   -------------------------------------------------------------------------- */
+:root {
+  --cube-font-family: '喜鹊万人造字体', sans-serif;
+  --cube-page-bg: #d1d5db;
+  --cube-page-bg-warm: #f6eee6;
+  --cube-brand-red: #d84a4a;
+  --cube-brand-red-soft: #f06f61;
+  --cube-text: #070d15;
+  --cube-text-muted: rgba(7, 13, 21, 0.52);
+  --cube-track: rgba(0, 0, 0, 0.2);
+  --cube-button: rgba(7, 13, 21, 0.32);
+  --cube-button-hover: var(--cube-brand-red);
+  --cube-focus-ring: rgba(216, 74, 74, 0.38);
+  --cube-handle: #41aac8;
+  --cube-white: #fff;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font: inherit;
+  cursor: inherit;
+  user-select: none;
+}
+
+html {
+  height: 100%;
+  overflow: hidden;
+  -webkit-tap-highlight-color: transparent;
+  text-size-adjust: 100%;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  height: 100%;
+  overflow: hidden;
+  font-family: var(--cube-font-family);
+  font-size: clamp(2.2rem, 8vw, 5rem);
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  color: var(--cube-text);
+  cursor: default;
+}
+
+button,
+[role='button'],
+.range__handle {
+  outline: 0;
+}
+
+button:focus-visible,
+[role='button']:focus-visible,
+.range__handle:focus-visible,
+.range:focus-within .range__handle div {
+  outline: 0.08em solid var(--cube-brand-red);
+  outline-offset: 0.12em;
+  box-shadow: 0 0 0 0.12em var(--cube-focus-ring);
+}
+
+.icon {
+  display: inline-block;
+  overflow: visible;
+  font-size: inherit;
+  vertical-align: -0.125em;
+  preserveAspectRatio: none;
+}
+
+/* --------------------------------------------------------------------------
+   layout
+   -------------------------------------------------------------------------- */
+.ui,
+.ui__background,
+.ui__game,
+.ui__texts,
+.ui__prefs,
+.ui__theme,
+.ui__stats,
+.ui__buttons {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+
+.ui {
+  pointer-events: none;
+  color: var(--cube-text);
+}
+
+.ui__background {
+  z-index: 1;
+  background: var(--cube-page-bg);
+  transition: background 500ms ease;
+}
+
+.ui__background::after {
+  position: absolute;
+  inset: 0;
+  content: '';
+  background-image: linear-gradient(to bottom, var(--cube-white) 50%, rgba(255, 255, 255, 0) 100%);
+}
+
+.ui__game {
+  z-index: 2;
+  pointer-events: all;
+}
+
+.ui__game canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.ui__texts {
+  z-index: 3;
+}
+
+.ui__prefs,
+.ui__stats,
+.ui__theme {
+  z-index: 4;
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.ui__theme {
+  padding-top: 15em;
+}
+
+.ui__buttons {
+  z-index: 5;
+}
+
+/* --------------------------------------------------------------------------
+   controls
+   -------------------------------------------------------------------------- */
+.range {
+  position: relative;
+  z-index: 1;
+  width: 14em;
+  max-width: calc(100vw - 2rem);
+  opacity: 0;
+}
+
+.range:not(:last-child) {
+  margin-bottom: 2em;
+}
+
+.range__label {
+  position: relative;
+  z-index: 2;
+  padding-bottom: 0.5em;
+  font-size: 0.9em;
+  line-height: 0.75em;
+}
+
+.range__track {
+  position: relative;
+  z-index: 3;
+  height: 1em;
+  margin-right: 0.5em;
+  margin-left: 0.5em;
+}
+
+.range__track-line {
+  position: absolute;
+  top: 50%;
+  right: -0.5em;
+  left: -0.5em;
+  height: 2px;
+  margin-top: -1px;
+  background: var(--cube-track);
+  transform-origin: left center;
+}
+
+.range__handle {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  z-index: 1;
+  width: 0;
+  height: 0;
+  cursor: pointer;
+}
+
+.range__handle div {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0.9em;
+  height: 0.9em;
+  margin-top: -0.45em;
+  margin-left: -0.45em;
+  background: var(--cube-handle);
+  border-bottom: 2px solid var(--cube-track);
+  border-radius: 0.2em;
+  transition: background 500ms ease;
+}
+
+.range.is-active .range__handle div {
+  transform: scale(1.25);
+}
+
+.range__handle::after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 3em;
+  height: 3em;
+  margin-top: -1.5em;
+  margin-left: -1.5em;
+  content: '';
+}
+
+.range__list {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+  padding-top: 0.5em;
+  font-size: 0.55em;
+  color: var(--cube-text-muted);
+}
+
+.range--type-color:not(:last-child) {
+  margin-bottom: 1em;
+}
+
+.range--type-color .range__list {
+  display: none;
+}
+
+.range--type-color .range__handle > div {
+  background: currentColor !important;
+}
+
+.range--type-color .range__track-line {
+  background: transparent;
+}
+
+.range--type-color .range__track-line::after {
+  position: absolute;
+  inset: 0;
+  content: '';
+  opacity: 0.5;
+}
+
+.range--color-hue .range__handle,
+.range--color-hue .range__track,
+.range--color-saturation .range__handle,
+.range--color-saturation .range__track,
+.range--color-lightness .range__handle,
+.range--color-lightness .range__track {
+  color: red;
+}
+
+.range--color-hue .range__track-line::after {
+  background: linear-gradient(to right, red, #ff0, lime, cyan, blue, #f0f, red);
+}
+
+.range--color-saturation .range__track-line::after {
+  background: linear-gradient(to right, gray, currentColor);
+}
+
+.range--color-lightness .range__track-line::after {
+  background: linear-gradient(to right, #000, currentColor, #fff);
+}
+
+/* --------------------------------------------------------------------------
+   texts
+   -------------------------------------------------------------------------- */
+.text {
+  position: absolute;
+  right: 0;
+  left: 0;
+  text-align: center;
+  line-height: 0.75;
+  perspective: 100rem;
+  opacity: 0;
+}
+
+.text i {
+  display: inline-block;
+  white-space: pre-wrap;
+  opacity: 0;
+}
+
+.text--title {
+  bottom: 75%;
+  height: 1.2em;
+  font-size: 4.4em;
+}
+
+.text--title span {
+  display: block;
+}
+
+.text--title span:first-child {
+  margin-bottom: 0.2em;
+  font-size: 0.5em;
+}
+
+.text--note {
+  top: 87%;
+  font-size: 1em;
+}
+
+.text--timer {
+  bottom: 78%;
+  font-size: 3.5em;
+  line-height: 1;
+}
+
+.text--complete,
+.text--best-time {
+  top: 83%;
+  font-size: 1.5em;
+  line-height: 1em;
+}
+
+.stats {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  justify-content: space-between;
+  width: 14em;
+  max-width: calc(100vw - 2rem);
+  opacity: 0;
+}
+
+.stats:not(:last-child) {
+  margin-bottom: 1.5em;
+}
+
+.stats > i {
+  display: block;
+  color: var(--cube-text-muted);
+  font-size: 0.9em;
+}
+
+.stats > b {
+  display: block;
+  font-size: 0.9em;
+}
+
+.stats > b > i {
+  font-size: 0.75em;
+}
+
+.stats[name='worst-time'] {
+  display: none;
+}
+
+/* --------------------------------------------------------------------------
+   buttons
+   -------------------------------------------------------------------------- */
+.btn {
+  position: absolute;
+  color: var(--cube-button);
+  pointer-events: none;
+  appearance: none;
+  background-color: transparent;
+  border: 0;
+  border-radius: 0;
+  font-size: 1.2em;
+  opacity: 0;
+  transition: color 180ms ease, transform 180ms ease;
+}
+
+.btn:hover,
+.btn:focus-visible {
+  color: var(--cube-button-hover);
+}
+
+.btn:focus-visible {
+  transform: translateY(-0.04em);
+}
+
+.btn::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 3em;
+  height: 3em;
+  margin-top: -1.5em;
+  margin-left: -1.5em;
+  border-radius: 100%;
+  content: '';
+}
+
+.btn--tr {
+  top: 0.8em;
+  right: 0.8em;
+}
+
+.btn--tl {
+  top: 0.8em;
+  left: 0.8em;
+}
+
+.btn--bl {
+  bottom: 0.8em;
+  left: 0.8em;
+}
+
+.btn--br {
+  right: 0.8em;
+  bottom: 0.8em;
+}
+
+.btn--bc {
+  bottom: 0.8em;
+  left: calc(50% - 0.5em);
+}
+
+.btn svg {
+  display: block;
+}
+
+/* --------------------------------------------------------------------------
+   theme
+   -------------------------------------------------------------------------- */
+.theme-warm {
+  --cube-page-bg: var(--cube-page-bg-warm);
+  --cube-text: #301f1a;
+  --cube-text-muted: rgba(48, 31, 26, 0.56);
+  --cube-button: rgba(48, 31, 26, 0.34);
+  --cube-button-hover: var(--cube-brand-red-soft);
+  --cube-handle: var(--cube-brand-red-soft);
+}
+
+@media (max-width: 640px) {
+  body {
+    font-size: clamp(1.45rem, 10vw, 2.75rem);
   }
-*,*:before,*:after{-webkit-user-select:none;-moz-user-select:none;user-select:none;box-sizing:border-box;cursor:inherit;margin:0;padding:0;outline:none;font-size:inherit;font-family:inherit;font-weight:inherit;font-style:inherit;text-transform:uppercase}*:focus{outline:none}html{-webkit-tap-highlight-color:transparent;-webkit-text-size-adjust:100%;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;overflow:hidden;height:100%}body{font-family:'喜鹊万人造字体', sans-serif;font-weight:normal;font-style:normal;line-height:1;cursor:default;overflow:hidden;height:100%;font-size:5rem}.icon{display:inline-block;font-size:inherit;overflow:visible;vertical-align:-0.125em;preserveAspectRatio:none}.range{position:relative;width:14em;z-index:1;opacity:0}.range:not(:last-child){margin-bottom:2em}.range__label{position:relative;font-size:0.9em;line-height:0.75em;padding-bottom:0.5em;z-index:2}.range__track{position:relative;height:1em;margin-left:0.5em;margin-right:0.5em;z-index:3}.range__track-line{position:absolute;background:rgba(0,0,0,0.2);height:2px;top:50%;margin-top:-1px;left:-0.5em;right:-0.5em;transform-origin:left center}.range__handle{position:absolute;width:0;height:0;top:50%;left:0;cursor:pointer;z-index:1}.range__handle div{transition:background 500ms ease;position:absolute;left:0;top:0;width:0.9em;height:0.9em;border-radius:0.2em;margin-left:-0.45em;margin-top:-0.45em;background:#41aac8;border-bottom:2px solid rgba(0,0,0,0.2)}.range.is-active .range__handle div{transform:scale(1.25)}.range__handle:after{content:'';position:absolute;left:0;top:0;width:3em;height:3em;margin-left:-1.5em;margin-top:-1.5em}.range__list{display:flex;flex-flow:row nowrap;justify-content:space-between;position:relative;padding-top:0.5em;font-size:0.55em;color:rgba(0,0,0,0.5);z-index:1}.range--type-color:not(:last-child){margin-bottom:1em}.range--type-color .range__list{display:none}.range--type-color .range__handle>div{background:currentColor !important}.range--type-color .range__track-line{background:transparent}.range--type-color .range__track-line:after{position:absolute;top:0;left:0;right:0;bottom:0;content:'';opacity:0.5}.range--color-hue .range__handle{color:red}.range--color-hue .range__track{color:red}.range--color-hue .range__track-line:after{background:linear-gradient(to right, red, #ff0, lime, cyan, blue, #f0f, red)}.range--color-saturation .range__handle{color:red}.range--color-saturation .range__track{color:red}.range--color-saturation .range__track-line:after{background:linear-gradient(to right, gray, currentColor)}.range--color-lightness .range__handle{color:red}.range--color-lightness .range__track{color:red}.range--color-lightness .range__track-line:after{background:linear-gradient(to right, #000, currentColor, #fff)}.stats{position:relative;width:14em;z-index:1;display:flex;justify-content:space-between;opacity:0}.stats:not(:last-child){margin-bottom:1.5em}.stats>i{display:block;color:rgba(0,0,0,0.5);font-size:0.9em}.stats>b{display:block;font-size:0.9em}.stats>b>i{font-size:0.75em}.stats[name="worst-time"]{display:none}.text{position:absolute;left:0;right:0;text-align:center;line-height:0.75;perspective:100rem;opacity:0}.text i{display:inline-block;opacity:0;white-space:pre-wrap}.text--title{bottom:75%;font-size:4.4em;height:1.2em}.text--title span{display:block}.text--title span:first-child{font-size:0.5em;margin-bottom:0.2em}.text--note{top:87%;font-size:1em}.text--timer{bottom:78%;font-size:3.5em;line-height:1}.text--complete,.text--best-time{font-size:1.5em;top:83%;line-height:1em}.btn{-webkit-appearance:none;-moz-appearance:none;appearance:none;background-color:transparent;border-radius:0;border-width:0;position:absolute;pointer-events:none;font-size:1.2em;color:rgba(0,0,0,0.25);opacity:0}.btn:after{position:absolute;content:'';width:3em;height:3em;left:50%;top:50%;margin-left:-1.5em;margin-top:-1.5em;border-radius:100%}.btn--tr{top:0.8em;right:0.8em}.btn--tl{top:0.8em;left:0.8em}.btn--bl{bottom:0.8em;left:0.8em}.btn--br{bottom:0.8em;right:0.8em}.btn--bc{bottom:0.8em;left:calc(50% - 0.5em)}.btn svg{display:block}.ui{pointer-events:none;color:#070d15}.ui,.ui__background,.ui__game,.ui__texts,.ui__prefs,.ui__theme,.ui__stats,.ui__buttons{position:absolute;top:0;left:0;right:0;bottom:0;overflow:hidden}.ui__background{z-index:1;transition:background 500ms ease;background:#d1d5db}.ui__background:after{position:absolute;top:0;left:0;right:0;bottom:0;content:'';background-image:linear-gradient(to bottom, #fff 50%, rgba(255,255,255,0) 100%)}.ui__game{pointer-events:all;z-index:2}.ui__game canvas{display:block;width:100%;height:100%}.ui__texts{z-index:3}.ui__prefs,.ui__stats,.ui__theme{display:flex;flex-flow:column nowrap;justify-content:center;align-items:center;overflow:hidden;z-index:4}.ui__theme{padding-top:15em}.ui__buttons{z-index:5}
+
+  .range,
+  .stats {
+    width: min(12em, calc(100vw - 2rem));
+  }
+
+  .range:not(:last-child) {
+    margin-bottom: 1.35em;
+  }
+
+  .stats:not(:last-child) {
+    margin-bottom: 1em;
+  }
+
+  .ui__theme {
+    padding-top: 10em;
+  }
+
+  .text--title {
+    font-size: 3.2em;
+  }
+
+  .text--timer {
+    font-size: 2.4em;
+  }
+
+  .btn--bl,
+  .btn--br,
+  .btn--bc {
+    bottom: 1.1em;
+  }
+
+  .btn--bl {
+    left: 1.1em;
+  }
+
+  .btn--br {
+    right: 1.1em;
+  }
+}

--- a/source/cube/index.html
+++ b/source/cube/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="zh-CN" class="theme-warm">
 <head>
 
   <meta charset="UTF-8">
@@ -18,7 +18,8 @@
   <link rel="manifest" href="assets/icons/site.webmanifest">
   <link rel="mask-icon" href="assets/icons/safari-pinned-tab.svg" color="#5bbad5">
   <link rel="shortcut icon" href="assets/icons/favicon.ico">
-  <meta name="theme-color" content="#ffffff">
+  <meta name="theme-color" content="#f6eee6">
+  <title>魔方 - CodeSyn</title>
 
   <link rel="stylesheet" type="text/css" href="assets/css/styles.css">
 


### PR DESCRIPTION
### Motivation
- 将魔方页面的压缩 CSS 转为可维护结构，便于后续主题/可访问性调整并与主站视觉保持一致。 
- 修复全局样式对中文文本与交互焦点的副作用，提升可访问性与移动端阅读体验。 

### Description
- 将 `source/cube/assets/css/styles.css` 从一行压缩样式重写并按 `base`、`layout`、`controls`、`texts`、`buttons`、`theme` 分段组织，同时加入 `:root` CSS 变量（背景、文字、按钮、焦点、滑块等）。
- 移除全局 `text-transform: uppercase` 和广泛的 `*:focus{outline:none}`，为交互元素增加 `:focus-visible` 样式并为按钮、`[role="button"]` 与 `.range__handle` 提供可见焦点环（使用品牌红变量）。
- 增加可选 `.theme-warm` 主题并将页面根元素设置为 `class="theme-warm"`，同时在 `source/cube/index.html` 添加 `lang="zh-CN"`、更新 `theme-color` 元信息与页面 `<title>`，让魔方页与主站品牌色建立视觉关联。 
- 添加移动端 media query，使用 `clamp()` 限制 `body` 字号并收紧控件间距，避免原先 `font-size:5rem` 在小屏上过大。 

### Testing
- 运行了文件内容检查命令 `rg "outline\s*:\s*none|text-transform\s*:\s*uppercase|\*:focus" source/cube/assets/css/styles.css`，确认已移除全局 uppercase / outline none（成功）。
- 在本地使用 `python3 -m http.server 8000` 并用 `curl -I http://127.0.0.1:8000/source/cube/` 验证页面可被服务器响应（成功）。
- 运行小脚本检查 CSS 括号匹配与基本重置项（`python3 - <<'PY' ...`），确认 brace balance 正常且重置按预期修改（成功）。
- 运行 `git diff --check` 并提交改动为提交信息 `Improve cube page visual styling`（成功）；因环境中未安装可用浏览器，未做截图式的视觉回归自动化测试（已记录）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a562c0eee4c8321b5607d75045991c8)