### PR TITLE
Optimize theme font loading

### DIFF
--- a/themes/hexo-xnew/source/styles/basic.styl
+++ b/themes/hexo-xnew/source/styles/basic.styl
@@ -1,22 +1,5 @@
-@font-face {
-  /* font-properties */
-  font-family: '喜鹊招牌体';
-  src: url('https://dm.nbut.ac.cn/xcoder/%E5%96%9C%E9%B9%8A%E6%8B%9B%E7%89%8C%E4%BD%93(%E7%AE%80%20%E7%B9%81%E4%BD%93).ttf');
-}
-
-@font-face {
-  /* font-properties */
-  font-family: '喜鹊聚珍体';
-  src: url('https://dm.nbut.ac.cn/xcoder/喜鹊聚珍体.ttf');
-}
-
-@font-face {
-  /* font-properties */
-  font-family: '喜鹊万人造字体';
-  src: url('https://dm.nbut.ac.cn/xcoder/%E5%96%9C%E9%B9%8A%E4%B8%87%E4%BA%BA%E9%80%A0%E5%AD%97%E4%BD%93.ttf');
-}
-
 article.full
+  font-family $body-font-family
   a
     color $link-color
     transition color ease .3s
@@ -79,7 +62,7 @@ article.full
   .post-image--small
     max-width 70%
   code
-    font-family "Fantasque Sans Mono"
+    font-family $code-font-family
   p code,
   li code
     background #282828

--- a/themes/hexo-xnew/source/styles/header.styl
+++ b/themes/hexo-xnew/source/styles/header.styl
@@ -19,7 +19,7 @@ header
   a
     color $header-line-color
   h1
-    font-family: '喜鹊招牌体', $cu-font-family;
+    font-family $heading-font-family
     font-weight: normal;
     font-size 2.6em
     margin-top 20px
@@ -30,7 +30,7 @@ header
       color $title-color
   p
     color $description-color
-    font-family: '喜鹊万人造字体', $cu-font-family;
+    font-family $tagline-font-family
     letter-spacing 0
     margin 0 auto
     max-width 22em
@@ -43,7 +43,7 @@ header
       margin 0
       padding 0
       li
-        font-family: '喜鹊聚珍体', $cu-font-family;
+        font-family $nav-font-family
         color $header-line-color
         display inline-block
         padding 12px 0 12px 12px

--- a/themes/hexo-xnew/source/styles/screen.styl
+++ b/themes/hexo-xnew/source/styles/screen.styl
@@ -6,6 +6,7 @@ body
   margin 0
   height 100vh
   font-size 16px
+  font-family $body-font-family
   flex-direction column
   .backstretch
     opacity .7

--- a/themes/hexo-xnew/source/styles/variables.styl
+++ b/themes/hexo-xnew/source/styles/variables.styl
@@ -13,10 +13,37 @@ $link-article-color = $title-color
 
 $background-color = #f7f6f5
 
-$cu-font-family = -apple-system, "Helvetica Neue", Arial, "PingFang SC", "lucida grande", "lucida sans unicode", lucida, helvetica, "Hiragino Sans GB", "Microsoft YaHei", "WenQuanYi Micro Hei", sans-serif
+$system-sans-font-family = -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "WenQuanYi Micro Hei", sans-serif
+$body-font-family = $system-sans-font-family
+$heading-font-family = '喜鹊招牌体', 'STKaiti', 'KaiTi', 'Kaiti SC', 'Songti SC', $system-sans-font-family
+$tagline-font-family = '喜鹊万人造字体', 'STKaiti', 'KaiTi', 'Kaiti SC', 'Songti SC', $system-sans-font-family
+$nav-font-family = '喜鹊聚珍体', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', $system-sans-font-family
+$code-font-family = "Fantasque Sans Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace
+$cu-font-family = $body-font-family
+
+// Decorative Chinese fonts are loaded only from optional local theme assets.
+// Keep licensed woff2/woff files in source/styles/font/ before enabling distribution;
+// no remote TTF fallback is used here to avoid render blocking and unclear redistribution rights.
+@font-face
+  font-family '喜鹊招牌体'
+  src url('font/xique-zhaopaiti.woff2') format('woff2'),
+      url('font/xique-zhaopaiti.woff') format('woff')
+  font-display swap
 
 @font-face
-  font-family: 'xnews-icon';  /* Project id 1265703 */
-  src: url('//at.alicdn.com/t/font_1265703_oecq9f006l.woff2?t=1631967542209') format('woff2'),
-       url('//at.alicdn.com/t/font_1265703_oecq9f006l.woff?t=1631967542209') format('woff'),
-       url('//at.alicdn.com/t/font_1265703_oecq9f006l.ttf?t=1631967542209') format('truetype');
+  font-family '喜鹊聚珍体'
+  src url('font/xique-juzhenti.woff2') format('woff2'),
+      url('font/xique-juzhenti.woff') format('woff')
+  font-display swap
+
+@font-face
+  font-family '喜鹊万人造字体'
+  src url('font/xique-wanrenzaoziti.woff2') format('woff2'),
+      url('font/xique-wanrenzaoziti.woff') format('woff')
+  font-display swap
+
+@font-face
+  font-family 'xnews-icon'  /* Project id 1265703 */
+  src url('//at.alicdn.com/t/font_1265703_oecq9f006l.woff2?t=1631967542209') format('woff2'),
+      url('//at.alicdn.com/t/font_1265703_oecq9f006l.woff?t=1631967542209') format('woff')
+  font-display swap


### PR DESCRIPTION
### Motivation
- Reduce render-blocking remote TTF usage and make decorative Chinese fonts optional/local to the theme to avoid redistribution/licensing issues. 
- Ensure stable fallback stacks for body, headings, navigation and code so layout remains consistent when custom fonts fail to load. 
- Improve performance and UX by preferring `woff2`/`woff` and using `font-display: swap` for non-blocking font fallback.

### Description
- Introduce new font family variables in `themes/hexo-xnew/source/styles/variables.styl`: `$system-sans-font-family`, `$body-font-family`, `$heading-font-family`, `$tagline-font-family`, `$nav-font-family`, and `$code-font-family` to separate body/heading/tagline/nav/code stacks. 
- Replace remote `.ttf` `@font-face` declarations with optional local `@font-face` entries that prefer `woff2`/`woff` under `source/styles/font/` and add `font-display: swap` for each face in `variables.styl`. 
- Remove the inline remote decorative TTFs from `basic.styl` and make the article/body use the system body stack (`$body-font-family`) and code blocks use `$code-font-family`. 
- Update `header.styl` and `screen.styl` to use the new variables so decorative fonts are limited to headings/navigation/tagline while body text falls back to system fonts.

### Testing
- Attempted `npm run build` but the environment lacks a global `hexo` binary, so the build could not be executed (`sh: 1: hexo: not found`).
- Attempted Stylus compile with `npx stylus` to validate generated CSS but `npx` failed to fetch `stylus` from the npm registry (403), so compilation check could not complete. 
- Ran `npm ci` to prepare dependencies but it produced many deprecation warnings and a long-running install; no site generation step was successfully completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a562c0c72408321bc9e6f56a692a859)