### PR TITLE
Fix theme page scrolling layout

### DIFF
--- a/themes/hexo-xnew/source/styles/screen.styl
+++ b/themes/hexo-xnew/source/styles/screen.styl
@@ -4,7 +4,7 @@
 body
   color $body-color
   margin 0
-  height 100vh
+  min-height 100vh
   font-size 16px
   flex-direction column
   .backstretch
@@ -18,10 +18,23 @@ body
       opacity .5
 
 header, main
-  overflow-y auto
-  -webkit-overflow-scrolling touch
+  box-sizing border-box
   padding 20px
 
 @import 'header.styl'
 @import 'main.styl'
 @import 'basic.styl'
+
+@media (min-width 720px)
+  body
+    align-items flex-start
+    header
+      height 100vh
+      position sticky
+      top 0
+    main
+      min-height 100vh
+
+@media (max-width 719px)
+  body
+    display block


### PR DESCRIPTION
### Motivation
- 避免页面被固定为首屏高度并阻止正文自然滚动，从而改善桌面与移动端的首屏/滚动体验。 
- 只在桌面端保留双栏布局且仅把侧栏（`header`）设为粘性以实现固定侧栏需求，避免把正文（`main`）变为独立滚动容器。 
- 在移动端恢复单列自然流式布局，减少 header 占满首屏的问题。 

### Description
- 将 `body` 的 `height: 100vh` 改为 `min-height: 100vh`，以允许页面超出视口高度时自然延伸。 
- 移除 `header, main` 上默认的 `overflow-y: auto` / `-webkit-overflow-scrolling`，并改为 `box-sizing: border-box` 与统一 `padding`，使正文随页面滚动。 
- 在 `@media (min-width 720px)` 中保持 `display: flex` 双栏布局，但为 `header` 添加 `height: 100vh; position: sticky; top: 0`，并只为 `main` 设置 `min-height: 100vh`，不再成为独立滚动容器。 
- 在 `@media (max-width 719px)` 中显式将 `body` 设置为 `display: block`，恢复移动端单列自然流。 

### Testing
- 运行 `git diff --check` 检查差异无语法问题，检查通过。 
- 运行 `npm run build` 会调用 `hexo generate`，但在当前环境失败（`hexo: not found`），因此构建未能在此环境完成。 
- 尝试运行 `npm ci` 以安装依赖时因环境/进程问题未能完成（安装过程长时间无输出且最终被终止）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a562c0a22948321bd161222f81dfae6)