### PR TITLE
Optimize article TOC layout

### DIFF
--- a/themes/hexo-xnew/source/styles/main.styl
+++ b/themes/hexo-xnew/source/styles/main.styl
@@ -84,17 +84,42 @@ main
   .article-toc
     box-sizing border-box
     max-width 100%
-    float right
-    border-radius 15px
-    border 1px solid $border-color
-    padding 2rem
-    margin-left 20px
     display none
+    background rgba(255, 255, 255, .72)
+    border 1px solid rgba(0, 0, 0, .06)
+    border-radius 16px
+    box-shadow 0 10px 28px rgba(0, 0, 0, .05)
+    color lighten($body-color, 18%)
+    font-size .88rem
+    line-height 1.65
+    margin 18px 0 28px
+    padding 1rem 1.15rem
+    strong
+      color $body-color
+      display block
+      font-family: '喜鹊招牌体', $cu-font-family;
+      font-size 1rem
+      font-weight normal
+      margin-bottom .55rem
     ol
       list-style none
-      list-style-position inside
+      margin 0
       padding 0
-      padding-left 15px
+      ol
+        border-left 1px solid rgba(0, 0, 0, .06)
+        margin .22rem 0 .28rem .35rem
+        padding-left .75rem
+    li
+      margin .18rem 0
+    a
+      border-radius 8px
+      color lighten($body-color, 12%)
+      display block
+      padding .08rem .25rem
+      transition background .2s ease, color .2s ease
+      &:hover
+        background rgba(0, 0, 0, .035)
+        color $body-link-hover-color
   footer
     &:before
       clear both
@@ -132,3 +157,23 @@ main
           margin-top 34px
       .article-toc
         display block
+
+@media (min-width 1100px)
+  body
+    main
+      article.full
+        align-items start
+        display grid
+        gap 0 32px
+        grid-template-columns minmax(0, 1fr) 240px
+        > *
+          grid-column 1
+        .article-toc
+          align-self start
+          grid-column 2
+          grid-row 1 / span 999
+          margin 0
+          max-height calc(100vh - 48px)
+          overflow auto
+          position sticky
+          top 24px


### PR DESCRIPTION
### Motivation

- Remove the float-based `.article-toc` layout to avoid it squeezing article content and to support a stable sidebar on large screens. 
- Provide a clearer desktop article layout and a fallback card-style TOC when template structure is not changed. 
- Improve TOC visual hierarchy with lower-contrast borders, subtle background, rounded corners and tighter spacing to reduce visual noise. 
- Keep TOC hidden or unobtrusive on small screens to avoid clutter on mobile.

### Description

- Replaced `float: right` on `.article-toc` with a non-floating card style (semi-transparent background, subtle border `rgba(0,0,0,.06)`, rounded corners, shadow, smaller font and padding) in `themes/hexo-xnew/source/styles/main.styl`.
- Improved internal TOC hierarchy and spacing by resetting list styles, adding a faint left rule for nested `ol`, tighter `li` spacing, and block link areas with hover background and color transitions.
- Kept the TOC hidden by default and shown at the existing tablet breakpoint (`@media (min-width 720px)`) as a top-of-content card to avoid float-based layout regressions.
- Added a desktop layout at `@media (min-width 1100px)` that uses CSS Grid on `article.full` to place the article content and a sticky TOC sidebar (`grid-template-columns: minmax(0, 1fr) 240px` and `.article-toc { position: sticky; top: 24px; }`) and constrained the TOC height with `max-height` + `overflow: auto`.

### Testing

- Ran `git diff --check` to validate there are no whitespace issues and it succeeded.
- Attempted `npm run build` to generate the site, but the build failed because the local `hexo` binary was not available in this environment (`sh: 1: hexo: not found`).
- No automated visual or browser tests were run due to the missing Hexo runtime, so review is recommended in a local dev environment or CI that can run `hexo generate`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a562c0a20f88321ad454d78ec7806b8)